### PR TITLE
Add roadmap and automation

### DIFF
--- a/.github/workflows/roadmap.yml
+++ b/.github/workflows/roadmap.yml
@@ -1,0 +1,28 @@
+name: Update Roadmap
+on:
+  pull_request:
+    types: [closed]
+permissions:
+  contents: write
+jobs:
+  strike:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Extract completed tags
+        id: tags
+        run: |
+          echo "tags=$(grep -oE 'closes TASK:[A-Z]+' <<< \"${{ github.event.pull_request.body }}\" | cut -d: -f2 | paste -sd ',' -)" >> "$GITHUB_OUTPUT"
+      - name: Update roadmap
+        env:
+          COMPLETED_TAGS: ${{ steps.tags.outputs.tags }}
+        run: python scripts/update_roadmap.py
+      - name: Commit changes
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+          git commit -am "chore(roadmap): auto-strike tasks" || echo "nothing to commit"
+          git push

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+### Roadmap auto-update
+Quand ta Pull Request termine une tâche, ajoute dans la description :
+✅ closes TASK:<TAG>   # ex. ✅ closes TASK:CI
+
+La ligne correspondante sera automatiquement cochée au merge.
+

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,17 @@
+# Roadmap
+
+## Phase 0 – Socle
+- [ ] <!--TASK:MONOREPO--> Initialisation du monorepo Poetry
+- [ ] <!--TASK:CI--> Mise en place qualite + CI
+
+## Phase 1 – Vision de base
+- [ ] <!--TASK:YOLO--> Detection YOLO + export JSON
+- [ ] <!--TASK:DEEPSORT--> Tracking DeepSORT
+
+## Phase 2 – Backend & DB
+- [ ] <!--TASK:DB--> Schema Postgres + migrations
+- [ ] <!--TASK:API--> API REST FastAPI
+
+## Phase 3 – Front
+- [ ] <!--TASK:CHART--> Shot-chart interactif
+- [ ] <!--TASK:DASHBOARD--> Dashboard stats live

--- a/scripts/update_roadmap.py
+++ b/scripts/update_roadmap.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import os, re, sys
+
+TAGS = [t.strip() for t in os.getenv("COMPLETED_TAGS", "").split(",") if t.strip()]
+if not TAGS:
+    sys.exit(0)
+
+roadmap = Path("ROADMAP.md")
+pattern = re.compile(r"^- \[ \] <!--TASK:(?P<tag>[A-Z]+)-->")
+
+updated = []
+for line in roadmap.read_text().splitlines():
+    m = pattern.match(line)
+    if m and m.group("tag") in TAGS:
+        line = line.replace("- [ ]", "- [x]", 1)
+        if "~~" not in line:
+            head, desc = line.split("-->", 1)
+            line = f"{head}-->{'~~' + desc.strip() + '~~'}"
+    updated.append(line)
+
+roadmap.write_text("\n".join(updated))


### PR DESCRIPTION
## Summary
- create project roadmap with task tags
- add script to auto-check roadmap items
- create workflow to update roadmap on merged PRs
- document how to use tags in CONTRIBUTING

## Testing
- `python scripts/update_roadmap.py`

------
https://chatgpt.com/codex/tasks/task_e_686d04142618832b9c4e9f9c45c0aaf9