### PR TITLE
Setup FastAPI monorepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.swp
+.poetry/

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+# Backend package

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+# Package marker

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root() -> dict[str, str]:
+    return {"message": "Hello world"}

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY pyproject.toml /app
+RUN pip install poetry && \
+    poetry config virtualenvs.create false && \
+    poetry install --no-root --only main
+
+COPY backend /app/backend
+COPY vision /app/vision
+
+EXPOSE 8000
+CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "basket_stats"
+version = "0.1.0"
+description = "Captation vidéo et statistiques basket – socle monorepo."
+authors = ["Benoît Bolivard <you@example.com>"]
+packages = [{ include = "backend" }, { include = "vision" }]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+fastapi = "^0.115.14"
+uvicorn = "^0.35.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.4.1"
+httpx = "^0.27.2"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from backend.app.main import app
+
+client = TestClient(app)
+
+def test_health() -> None:
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Hello world"}

--- a/vision/__init__.py
+++ b/vision/__init__.py
@@ -1,0 +1,1 @@
+# Computer-vision package placeholder


### PR DESCRIPTION
## Summary
- initialize Poetry project
- add FastAPI boilerplate app
- placeholder computer vision package
- add healthcheck test
- Dockerfile for backend service

✅ closes TASK:MONOREPO

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68741c19ff78832bb54fdb1c2f5b2ef1